### PR TITLE
Repository renamed to "transformation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ it works.
 
 ## Support
 
-We would love your feedback and help on this project, so don't hesitate to let us know what is wrong and how we could improve them, just file an [issue](https://github.com/triggermesh/transformation-prototype/issues/new) or join those of us who are maintaining them and submit a [PR](https://github.com/triggermesh/transformation-prototype/compare)
+We would love your feedback and help on this project, so don't hesitate to let us know what is wrong and how we could improve them, just file an [issue](https://github.com/triggermesh/transformation/issues/new) or join those of us who are maintaining them and submit a [PR](https://github.com/triggermesh/transformation/compare)
 
 ## Commercial Support
 

--- a/cmd/transformation-adapter/main.go
+++ b/cmd/transformation-adapter/main.go
@@ -24,8 +24,8 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 
-	"github.com/triggermesh/transformation-prototype/pkg/apis/transformation/v1alpha1"
-	"github.com/triggermesh/transformation-prototype/pkg/transformer"
+	"github.com/triggermesh/transformation/pkg/apis/transformation/v1alpha1"
+	"github.com/triggermesh/transformation/pkg/transformer"
 )
 
 const (

--- a/cmd/transformation-controller/main.go
+++ b/cmd/transformation-controller/main.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	// The set of controllers this controller process runs.
-	"github.com/triggermesh/transformation-prototype/pkg/reconciler/controller"
+	"github.com/triggermesh/transformation/pkg/reconciler/controller"
 
 	// This defines the shared main for injected controllers.
 	"knative.dev/pkg/injection/sharedmain"

--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -16,4 +16,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: transformation-controller
-  namespace: transformation
+  namespace: triggermesh

--- a/config/201-clusterrolebinding.yaml
+++ b/config/201-clusterrolebinding.yaml
@@ -19,7 +19,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: transformation-controller
-    namespace: transformation
+    namespace: triggermesh
 roleRef:
   kind: ClusterRole
   name: transformation-admin

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: transformation-controller
-  namespace: transformation
+  namespace: triggermesh
 spec:
   replicas: 1
   selector:
@@ -30,13 +30,13 @@ spec:
       serviceAccountName: transformation-controller
       containers:
       - name: controller
-        image: ko://github.com/triggermesh/transformation-prototype/cmd/transformation-controller
+        image: ko://github.com/triggermesh/transformation/cmd/transformation-controller
         ports:
         - name: metrics
           containerPort: 9090
         env:
         - name: TRANSFORMER_IMAGE
-          value: ko://github.com/triggermesh/transformation-prototype/cmd/transformation-adapter
+          value: ko://github.com/triggermesh/transformation/cmd/transformation-adapter
         - name: SYSTEM_NAMESPACE
           valueFrom:
             fieldRef:

--- a/config/config-leader-election.yaml
+++ b/config/config-leader-election.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-leader-election
-  namespace: transformation
+  namespace: triggermesh
 data:
   _example: |
     ################################

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-logging
-  namespace: transformation
+  namespace: triggermesh
 
 data:
   _example: |

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-observability
-  namespace: transformation
+  namespace: triggermesh
 
 data:
   _example: |

--- a/config/samples/triggers.yaml
+++ b/config/samples/triggers.yaml
@@ -12,7 +12,6 @@ spec:
       apiVersion: flow.triggermesh.io/v1alpha1
       kind: Transformation
       name: demo
-      namespace: default
 
 ---
 
@@ -30,4 +29,3 @@ spec:
       apiVersion: serving.knative.dev/v1
       kind: Service
       name: event-display
-      namespace: default

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/triggermesh/transformation-prototype
+module github.com/triggermesh/transformation
 
 go 1.14
 

--- a/hack/inc.Codegen.mk
+++ b/hack/inc.Codegen.mk
@@ -3,7 +3,7 @@
 # see https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md#generate-code
 
 # Name of the Go package for this repository
-PKG := github.com/triggermesh/transformation-prototype
+PKG := github.com/triggermesh/transformation
 
 # List of API groups to generate code for
 # e.g. "transformation/v1alpha1 transformation/v1alpha2"

--- a/hack/release-notes.sh
+++ b/hack/release-notes.sh
@@ -14,7 +14,7 @@ if ! git rev-list ${RELEASE} >/dev/null 2>&1; then
 	exit
 fi
 
-KREPO="transformation-prototype"
+KREPO="transformation"
 BASE_URL="https://github.com/triggermesh/${KREPO}/releases/download/${RELEASE}"
 PREV_RELEASE=${PREV_RELEASE:-$(git describe --tags --abbrev=0 ${RELEASE}^ 2>/dev/null)}
 PREV_RELEASE=${PREV_RELEASE:-$(git rev-list --max-parents=0 ${RELEASE}^ 2>/dev/null)}

--- a/pkg/apis/transformation/v1alpha1/register.go
+++ b/pkg/apis/transformation/v1alpha1/register.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/triggermesh/transformation-prototype/pkg/apis/transformation"
+	"github.com/triggermesh/transformation/pkg/apis/transformation"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/client/generated/clientset/internalclientset/clientset.go
+++ b/pkg/client/generated/clientset/internalclientset/clientset.go
@@ -21,7 +21,7 @@ package internalclientset
 import (
 	"fmt"
 
-	flowv1alpha1 "github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1"
+	flowv1alpha1 "github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"

--- a/pkg/client/generated/clientset/internalclientset/fake/clientset_generated.go
+++ b/pkg/client/generated/clientset/internalclientset/fake/clientset_generated.go
@@ -19,9 +19,9 @@ limitations under the License.
 package fake
 
 import (
-	clientset "github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset"
-	flowv1alpha1 "github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1"
-	fakeflowv1alpha1 "github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1/fake"
+	clientset "github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset"
+	flowv1alpha1 "github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1"
+	fakeflowv1alpha1 "github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"

--- a/pkg/client/generated/clientset/internalclientset/fake/register.go
+++ b/pkg/client/generated/clientset/internalclientset/fake/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	flowv1alpha1 "github.com/triggermesh/transformation-prototype/pkg/apis/transformation/v1alpha1"
+	flowv1alpha1 "github.com/triggermesh/transformation/pkg/apis/transformation/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/generated/clientset/internalclientset/scheme/register.go
+++ b/pkg/client/generated/clientset/internalclientset/scheme/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 package scheme
 
 import (
-	flowv1alpha1 "github.com/triggermesh/transformation-prototype/pkg/apis/transformation/v1alpha1"
+	flowv1alpha1 "github.com/triggermesh/transformation/pkg/apis/transformation/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1/fake/fake_transformation.go
+++ b/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1/fake/fake_transformation.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/triggermesh/transformation-prototype/pkg/apis/transformation/v1alpha1"
+	v1alpha1 "github.com/triggermesh/transformation/pkg/apis/transformation/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1/fake/fake_transformation_client.go
+++ b/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1/fake/fake_transformation_client.go
@@ -19,7 +19,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1"
+	v1alpha1 "github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
 )

--- a/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1/transformation.go
+++ b/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1/transformation.go
@@ -21,8 +21,8 @@ package v1alpha1
 import (
 	"time"
 
-	v1alpha1 "github.com/triggermesh/transformation-prototype/pkg/apis/transformation/v1alpha1"
-	scheme "github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset/scheme"
+	v1alpha1 "github.com/triggermesh/transformation/pkg/apis/transformation/v1alpha1"
+	scheme "github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1/transformation_client.go
+++ b/pkg/client/generated/clientset/internalclientset/typed/transformation/v1alpha1/transformation_client.go
@@ -19,8 +19,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/triggermesh/transformation-prototype/pkg/apis/transformation/v1alpha1"
-	"github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset/scheme"
+	v1alpha1 "github.com/triggermesh/transformation/pkg/apis/transformation/v1alpha1"
+	"github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset/scheme"
 	rest "k8s.io/client-go/rest"
 )
 

--- a/pkg/client/generated/informers/externalversions/factory.go
+++ b/pkg/client/generated/informers/externalversions/factory.go
@@ -23,9 +23,9 @@ import (
 	sync "sync"
 	time "time"
 
-	internalclientset "github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset"
-	internalinterfaces "github.com/triggermesh/transformation-prototype/pkg/client/generated/informers/externalversions/internalinterfaces"
-	transformation "github.com/triggermesh/transformation-prototype/pkg/client/generated/informers/externalversions/transformation"
+	internalclientset "github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset"
+	internalinterfaces "github.com/triggermesh/transformation/pkg/client/generated/informers/externalversions/internalinterfaces"
+	transformation "github.com/triggermesh/transformation/pkg/client/generated/informers/externalversions/transformation"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/generated/informers/externalversions/generic.go
+++ b/pkg/client/generated/informers/externalversions/generic.go
@@ -21,7 +21,7 @@ package externalversions
 import (
 	"fmt"
 
-	v1alpha1 "github.com/triggermesh/transformation-prototype/pkg/apis/transformation/v1alpha1"
+	v1alpha1 "github.com/triggermesh/transformation/pkg/apis/transformation/v1alpha1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
 )

--- a/pkg/client/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -21,7 +21,7 @@ package internalinterfaces
 import (
 	time "time"
 
-	internalclientset "github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset"
+	internalclientset "github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"

--- a/pkg/client/generated/informers/externalversions/transformation/interface.go
+++ b/pkg/client/generated/informers/externalversions/transformation/interface.go
@@ -19,8 +19,8 @@ limitations under the License.
 package transformation
 
 import (
-	internalinterfaces "github.com/triggermesh/transformation-prototype/pkg/client/generated/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/triggermesh/transformation-prototype/pkg/client/generated/informers/externalversions/transformation/v1alpha1"
+	internalinterfaces "github.com/triggermesh/transformation/pkg/client/generated/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/triggermesh/transformation/pkg/client/generated/informers/externalversions/transformation/v1alpha1"
 )
 
 // Interface provides access to each of this group's versions.

--- a/pkg/client/generated/informers/externalversions/transformation/v1alpha1/interface.go
+++ b/pkg/client/generated/informers/externalversions/transformation/v1alpha1/interface.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	internalinterfaces "github.com/triggermesh/transformation-prototype/pkg/client/generated/informers/externalversions/internalinterfaces"
+	internalinterfaces "github.com/triggermesh/transformation/pkg/client/generated/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/pkg/client/generated/informers/externalversions/transformation/v1alpha1/transformation.go
+++ b/pkg/client/generated/informers/externalversions/transformation/v1alpha1/transformation.go
@@ -21,10 +21,10 @@ package v1alpha1
 import (
 	time "time"
 
-	transformationv1alpha1 "github.com/triggermesh/transformation-prototype/pkg/apis/transformation/v1alpha1"
-	internalclientset "github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset"
-	internalinterfaces "github.com/triggermesh/transformation-prototype/pkg/client/generated/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/triggermesh/transformation-prototype/pkg/client/generated/listers/transformation/v1alpha1"
+	transformationv1alpha1 "github.com/triggermesh/transformation/pkg/apis/transformation/v1alpha1"
+	internalclientset "github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset"
+	internalinterfaces "github.com/triggermesh/transformation/pkg/client/generated/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/triggermesh/transformation/pkg/client/generated/listers/transformation/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/generated/injection/client/client.go
+++ b/pkg/client/generated/injection/client/client.go
@@ -21,7 +21,7 @@ package client
 import (
 	context "context"
 
-	internalclientset "github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset"
+	internalclientset "github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset"
 	rest "k8s.io/client-go/rest"
 	injection "knative.dev/pkg/injection"
 	logging "knative.dev/pkg/logging"
@@ -43,7 +43,7 @@ func Get(ctx context.Context) internalclientset.Interface {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		logging.FromContext(ctx).Panic(
-			"Unable to fetch github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset.Interface from context.")
+			"Unable to fetch github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset.Interface from context.")
 	}
 	return untyped.(internalclientset.Interface)
 }

--- a/pkg/client/generated/injection/client/fake/fake.go
+++ b/pkg/client/generated/injection/client/fake/fake.go
@@ -21,8 +21,8 @@ package fake
 import (
 	context "context"
 
-	fake "github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset/fake"
-	client "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/client"
+	fake "github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset/fake"
+	client "github.com/triggermesh/transformation/pkg/client/generated/injection/client"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	rest "k8s.io/client-go/rest"
 	injection "knative.dev/pkg/injection"
@@ -48,7 +48,7 @@ func Get(ctx context.Context) *fake.Clientset {
 	untyped := ctx.Value(client.Key{})
 	if untyped == nil {
 		logging.FromContext(ctx).Panic(
-			"Unable to fetch github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset/fake.Clientset from context.")
+			"Unable to fetch github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset/fake.Clientset from context.")
 	}
 	return untyped.(*fake.Clientset)
 }

--- a/pkg/client/generated/injection/informers/factory/factory.go
+++ b/pkg/client/generated/injection/informers/factory/factory.go
@@ -21,8 +21,8 @@ package factory
 import (
 	context "context"
 
-	externalversions "github.com/triggermesh/transformation-prototype/pkg/client/generated/informers/externalversions"
-	client "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/client"
+	externalversions "github.com/triggermesh/transformation/pkg/client/generated/informers/externalversions"
+	client "github.com/triggermesh/transformation/pkg/client/generated/injection/client"
 	controller "knative.dev/pkg/controller"
 	injection "knative.dev/pkg/injection"
 	logging "knative.dev/pkg/logging"
@@ -50,7 +50,7 @@ func Get(ctx context.Context) externalversions.SharedInformerFactory {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		logging.FromContext(ctx).Panic(
-			"Unable to fetch github.com/triggermesh/transformation-prototype/pkg/client/generated/informers/externalversions.SharedInformerFactory from context.")
+			"Unable to fetch github.com/triggermesh/transformation/pkg/client/generated/informers/externalversions.SharedInformerFactory from context.")
 	}
 	return untyped.(externalversions.SharedInformerFactory)
 }

--- a/pkg/client/generated/injection/informers/factory/fake/fake.go
+++ b/pkg/client/generated/injection/informers/factory/fake/fake.go
@@ -21,9 +21,9 @@ package fake
 import (
 	context "context"
 
-	externalversions "github.com/triggermesh/transformation-prototype/pkg/client/generated/informers/externalversions"
-	fake "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/client/fake"
-	factory "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/informers/factory"
+	externalversions "github.com/triggermesh/transformation/pkg/client/generated/informers/externalversions"
+	fake "github.com/triggermesh/transformation/pkg/client/generated/injection/client/fake"
+	factory "github.com/triggermesh/transformation/pkg/client/generated/injection/informers/factory"
 	controller "knative.dev/pkg/controller"
 	injection "knative.dev/pkg/injection"
 )

--- a/pkg/client/generated/injection/informers/transformation/v1alpha1/transformation/fake/fake.go
+++ b/pkg/client/generated/injection/informers/transformation/v1alpha1/transformation/fake/fake.go
@@ -21,8 +21,8 @@ package fake
 import (
 	context "context"
 
-	fake "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/informers/factory/fake"
-	transformation "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/informers/transformation/v1alpha1/transformation"
+	fake "github.com/triggermesh/transformation/pkg/client/generated/injection/informers/factory/fake"
+	transformation "github.com/triggermesh/transformation/pkg/client/generated/injection/informers/transformation/v1alpha1/transformation"
 	controller "knative.dev/pkg/controller"
 	injection "knative.dev/pkg/injection"
 )

--- a/pkg/client/generated/injection/informers/transformation/v1alpha1/transformation/transformation.go
+++ b/pkg/client/generated/injection/informers/transformation/v1alpha1/transformation/transformation.go
@@ -21,8 +21,8 @@ package transformation
 import (
 	context "context"
 
-	v1alpha1 "github.com/triggermesh/transformation-prototype/pkg/client/generated/informers/externalversions/transformation/v1alpha1"
-	factory "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/informers/factory"
+	v1alpha1 "github.com/triggermesh/transformation/pkg/client/generated/informers/externalversions/transformation/v1alpha1"
+	factory "github.com/triggermesh/transformation/pkg/client/generated/injection/informers/factory"
 	controller "knative.dev/pkg/controller"
 	injection "knative.dev/pkg/injection"
 	logging "knative.dev/pkg/logging"
@@ -46,7 +46,7 @@ func Get(ctx context.Context) v1alpha1.TransformationInformer {
 	untyped := ctx.Value(Key{})
 	if untyped == nil {
 		logging.FromContext(ctx).Panic(
-			"Unable to fetch github.com/triggermesh/transformation-prototype/pkg/client/generated/informers/externalversions/transformation/v1alpha1.TransformationInformer from context.")
+			"Unable to fetch github.com/triggermesh/transformation/pkg/client/generated/informers/externalversions/transformation/v1alpha1.TransformationInformer from context.")
 	}
 	return untyped.(v1alpha1.TransformationInformer)
 }

--- a/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation/controller.go
+++ b/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation/controller.go
@@ -24,9 +24,9 @@ import (
 	reflect "reflect"
 	strings "strings"
 
-	internalclientsetscheme "github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset/scheme"
-	client "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/client"
-	transformation "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/informers/transformation/v1alpha1/transformation"
+	internalclientsetscheme "github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset/scheme"
+	client "github.com/triggermesh/transformation/pkg/client/generated/injection/client"
+	transformation "github.com/triggermesh/transformation/pkg/client/generated/injection/informers/transformation/v1alpha1/transformation"
 	corev1 "k8s.io/api/core/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	types "k8s.io/apimachinery/pkg/types"

--- a/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation/reconciler.go
+++ b/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation/reconciler.go
@@ -24,9 +24,9 @@ import (
 	fmt "fmt"
 	reflect "reflect"
 
-	v1alpha1 "github.com/triggermesh/transformation-prototype/pkg/apis/transformation/v1alpha1"
-	internalclientset "github.com/triggermesh/transformation-prototype/pkg/client/generated/clientset/internalclientset"
-	transformationv1alpha1 "github.com/triggermesh/transformation-prototype/pkg/client/generated/listers/transformation/v1alpha1"
+	v1alpha1 "github.com/triggermesh/transformation/pkg/apis/transformation/v1alpha1"
+	internalclientset "github.com/triggermesh/transformation/pkg/client/generated/clientset/internalclientset"
+	transformationv1alpha1 "github.com/triggermesh/transformation/pkg/client/generated/listers/transformation/v1alpha1"
 	zap "go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	equality "k8s.io/apimachinery/pkg/api/equality"

--- a/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation/stub/controller.go
+++ b/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation/stub/controller.go
@@ -21,8 +21,8 @@ package transformation
 import (
 	context "context"
 
-	transformation "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/informers/transformation/v1alpha1/transformation"
-	v1alpha1transformation "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation"
+	transformation "github.com/triggermesh/transformation/pkg/client/generated/injection/informers/transformation/v1alpha1/transformation"
+	v1alpha1transformation "github.com/triggermesh/transformation/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation"
 	configmap "knative.dev/pkg/configmap"
 	controller "knative.dev/pkg/controller"
 	logging "knative.dev/pkg/logging"

--- a/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation/stub/reconciler.go
+++ b/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation/stub/reconciler.go
@@ -21,8 +21,8 @@ package transformation
 import (
 	context "context"
 
-	v1alpha1 "github.com/triggermesh/transformation-prototype/pkg/apis/transformation/v1alpha1"
-	transformation "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation"
+	v1alpha1 "github.com/triggermesh/transformation/pkg/apis/transformation/v1alpha1"
+	transformation "github.com/triggermesh/transformation/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation"
 	v1 "k8s.io/api/core/v1"
 	reconciler "knative.dev/pkg/reconciler"
 )

--- a/pkg/client/generated/listers/transformation/v1alpha1/transformation.go
+++ b/pkg/client/generated/listers/transformation/v1alpha1/transformation.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/triggermesh/transformation-prototype/pkg/apis/transformation/v1alpha1"
+	v1alpha1 "github.com/triggermesh/transformation/pkg/apis/transformation/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/reconciler/controller/controller.go
+++ b/pkg/reconciler/controller/controller.go
@@ -29,8 +29,8 @@ import (
 	servingv1client "knative.dev/serving/pkg/client/injection/client"
 	knsvcinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/service"
 
-	transformationinformer "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/informers/transformation/v1alpha1/transformation"
-	transformationreconciler "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation"
+	transformationinformer "github.com/triggermesh/transformation/pkg/client/generated/injection/informers/transformation/v1alpha1/transformation"
+	transformationreconciler "github.com/triggermesh/transformation/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation"
 )
 
 type envConfig struct {

--- a/pkg/reconciler/controller/transformation.go
+++ b/pkg/reconciler/controller/transformation.go
@@ -33,9 +33,9 @@ import (
 	servingv1client "knative.dev/serving/pkg/client/clientset/versioned"
 	servingv1listers "knative.dev/serving/pkg/client/listers/serving/v1"
 
-	transformationv1alpha1 "github.com/triggermesh/transformation-prototype/pkg/apis/transformation/v1alpha1"
-	transformationreconciler "github.com/triggermesh/transformation-prototype/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation"
-	"github.com/triggermesh/transformation-prototype/pkg/reconciler/controller/resources"
+	transformationv1alpha1 "github.com/triggermesh/transformation/pkg/apis/transformation/v1alpha1"
+	transformationreconciler "github.com/triggermesh/transformation/pkg/client/generated/injection/reconciler/transformation/v1alpha1/transformation"
+	"github.com/triggermesh/transformation/pkg/reconciler/controller/resources"
 )
 
 const (

--- a/pkg/transformer/operations/add/add.go
+++ b/pkg/transformer/operations/add/add.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/triggermesh/transformation-prototype/pkg/transformer/common/convert"
-	"github.com/triggermesh/transformation-prototype/pkg/transformer/common/storage"
+	"github.com/triggermesh/transformation/pkg/transformer/common/convert"
+	"github.com/triggermesh/transformation/pkg/transformer/common/storage"
 )
 
 // Add object implements Transformer interface.

--- a/pkg/transformer/operations/delete/delete.go
+++ b/pkg/transformer/operations/delete/delete.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/triggermesh/transformation-prototype/pkg/transformer/common/storage"
+	"github.com/triggermesh/transformation/pkg/transformer/common/storage"
 )
 
 // Delete object implements Transformer interface.

--- a/pkg/transformer/operations/pipeline.go
+++ b/pkg/transformer/operations/pipeline.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/triggermesh/transformation-prototype/pkg/apis/transformation/v1alpha1"
-	"github.com/triggermesh/transformation-prototype/pkg/transformer/common/storage"
-	"github.com/triggermesh/transformation-prototype/pkg/transformer/operations/add"
-	"github.com/triggermesh/transformation-prototype/pkg/transformer/operations/delete"
-	"github.com/triggermesh/transformation-prototype/pkg/transformer/operations/shift"
-	"github.com/triggermesh/transformation-prototype/pkg/transformer/operations/store"
+	"github.com/triggermesh/transformation/pkg/apis/transformation/v1alpha1"
+	"github.com/triggermesh/transformation/pkg/transformer/common/storage"
+	"github.com/triggermesh/transformation/pkg/transformer/operations/add"
+	"github.com/triggermesh/transformation/pkg/transformer/operations/delete"
+	"github.com/triggermesh/transformation/pkg/transformer/operations/shift"
+	"github.com/triggermesh/transformation/pkg/transformer/operations/store"
 )
 
 // Transformer is an interface that contains common methods

--- a/pkg/transformer/operations/shift/shift.go
+++ b/pkg/transformer/operations/shift/shift.go
@@ -20,8 +20,8 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/triggermesh/transformation-prototype/pkg/transformer/common/convert"
-	"github.com/triggermesh/transformation-prototype/pkg/transformer/common/storage"
+	"github.com/triggermesh/transformation/pkg/transformer/common/convert"
+	"github.com/triggermesh/transformation/pkg/transformer/common/storage"
 )
 
 // Shift object implements Transformer interface.

--- a/pkg/transformer/transformer.go
+++ b/pkg/transformer/transformer.go
@@ -23,9 +23,9 @@ import (
 	"log"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/triggermesh/transformation-prototype/pkg/apis/transformation/v1alpha1"
-	"github.com/triggermesh/transformation-prototype/pkg/transformer/common/storage"
-	"github.com/triggermesh/transformation-prototype/pkg/transformer/operations"
+	"github.com/triggermesh/transformation/pkg/apis/transformation/v1alpha1"
+	"github.com/triggermesh/transformation/pkg/transformer/common/storage"
+	"github.com/triggermesh/transformation/pkg/transformer/operations"
 )
 
 // Transformer contains Pipelines for CE Context and Data transformations.


### PR DESCRIPTION
I'm not good at projects naming so I just removed the "-prototype" part. Open to any other ideas as `transformation-prototype` is much easier to auto-replace than just `transformation`. 