### PR TITLE
Handle JSON arrays

### DIFF
--- a/pkg/transformer/operations/add/add.go
+++ b/pkg/transformer/operations/add/add.go
@@ -72,12 +72,12 @@ func (a *Add) New(key, value string) interface{} {
 // variables into existing JSON.
 func (a *Add) Apply(data []byte) ([]byte, error) {
 	input := convert.SliceToMap(strings.Split(a.Path, "."), a.composeValue())
-	event := make(map[string]interface{})
+	var event interface{}
 	if err := json.Unmarshal(data, &event); err != nil {
 		return data, err
 	}
 
-	result := convert.MergeMaps(event, input)
+	result := convert.MergeJSONWithMap(event, input)
 	output, err := json.Marshal(result)
 	if err != nil {
 		return data, err


### PR DESCRIPTION
Before, JSONs were considered as `map[string]interface{}` objects which leave arrays as a root object unhandled. Now they should be fine, although all these interfaces parsing become a bit cryptic; we should consider utilizing something like [gjson](https://github.com/tidwall/gjson) for JSON processing

The following case wasn't working before this fix:
store path: 
`[1].data.key`

JSON:
```
[
  {},
  {"data": {"key": "value2"}},
  {}
]
```