### PR TITLE
CloudEvent Attributes in Transformation CR Status

### DIFF
--- a/pkg/apis/transformation/v1alpha1/deepcopy_generated.go
+++ b/pkg/apis/transformation/v1alpha1/deepcopy_generated.go
@@ -162,6 +162,11 @@ func (in *TransformationStatus) DeepCopyInto(out *TransformationStatus) {
 		*out = new(v1.Addressable)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CloudEventAttributes != nil {
+		in, out := &in.CloudEventAttributes, &out.CloudEventAttributes
+		*out = make([]v1.CloudEventAttributes, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/transformation/v1alpha1/transformation_types.go
+++ b/pkg/apis/transformation/v1alpha1/transformation_types.go
@@ -64,6 +64,7 @@ type Transform struct {
 	Paths     []Path `json:"paths"`
 }
 
+// Path is a key-value pair that represents JSON object path
 type Path struct {
 	Key   string `json:"key,omitempty"`
 	Value string `json:"value,omitempty"`
@@ -82,6 +83,11 @@ type TransformationStatus struct {
 	// Address holds the information needed to connect this Addressable up to receive events.
 	// +optional
 	Address *duckv1.Addressable `json:"address,omitempty"`
+
+	// CloudEventAttributes are the specific attributes that the Transformation uses
+	// as part of its CloudEvents.
+	// +optional
+	CloudEventAttributes []duckv1.CloudEventAttributes `json:"ceAttributes,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
As we agreed, all CE producers must announce Type and Source of the Cloud Events they produce.
Since in Transformation user is deciding which Type and/or Source resulting Cloud Event will have, `createCloudEventAttributes()` function is trying to parse the object Spec to get required data; pretty ugly solution.
The option that I would prefer over this implementation is to automatically set new Type/Source for Cloud Events that are passing through the Transformation (this would also guarantee loop protection), but we didn't come to a common opinion here

Closes #29