### PR TITLE
CE Attributes added to CRD

### DIFF
--- a/config/300-transformation.yaml
+++ b/config/300-transformation.yaml
@@ -85,6 +85,15 @@ spec:
           status:
             type: object
             properties:
+              ceAttributes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    source:
+                      type: string
               observedGeneration:
                 type: integer
                 format: int64


### PR DESCRIPTION
For some reason, my local k3s is completely fine with having unknown CRD fields and I easily fall into this trap.
CE attributes are being parsed from the Spec and considered as optional, at least for now.