### PR TITLE
Prepend `bumblebee-` to internal controller component name

### DIFF
--- a/cmd/transformation-controller/main.go
+++ b/cmd/transformation-controller/main.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,5 +25,5 @@ import (
 )
 
 func main() {
-	sharedmain.Main("controller", controller.NewController)
+	sharedmain.Main("bumblebee-controller", controller.NewController)
 }


### PR DESCRIPTION
I noticed while troubleshooting some issues with leader election that leases generated by the Bumblebee controller are just called "controller":

```
event-sources-controller.github.com.triggermesh.event-sources.pkg.reconciler.azureactivitylogssource.reconciler.00-of-01
function-controller.github.com.triggermesh.function.pkg.reconciler.function.reconciler.00-of-01
knative-sources-controller.github.com-triggermesh-knative-sources-pkg-reconciler-httpsource.reconciler.00-of-01
controller.github.com-triggermesh-bumblebee-pkg-reconciler-controller.reconciler.00-of-01
 ▲
 └─ generic name
```

The main reason for not using such generic names is that it prevents us from adjusting the log level of specific components in `config-logging`:

```yaml
data:
  zap-logger-config: |
    [...]

  loglevel.controller: debug            # <-- which one?
  loglevel.bumblebee-controller: debug  # <-- now it does what we expect
```

It's also useful for differentiating bumblebee from other controllers in log aggregators:

```json
{"level":"info","ts":"2021-05-05T05:09:20.313Z","logger":"controller",
                                                           ▲
                                                           └─ not easy to tell the origin
 "caller":"leaderelection/context.go:46","msg":"Running with Standard leader election","commit":"053a2b8"}
```